### PR TITLE
FatalErrorException: Call to undefined method Illuminate\Support\Faca…

### DIFF
--- a/app/Http/routes.php
+++ b/app/Http/routes.php
@@ -27,7 +27,7 @@ Route::group(['middleware' => ['web']], function () {
     /**
      * Add New Task
      */
-    Route::post('/task', function (Request $request) {
+    Route::post('/task', function (Illuminate\Http\Request $request) {
         $validator = Validator::make($request->all(), [
             'name' => 'required|max:255',
         ]);


### PR DESCRIPTION
There has a conflict between Illuminate\Http\Request and Illuminate\Support\Facades\Request,so it's better to use "Illuminate\Http\Request" replace "Request"

![11](https://cloud.githubusercontent.com/assets/6275008/14038171/fff34416-f287-11e5-8e1a-33781311ebc7.png)
